### PR TITLE
Use pkg-config on Windows when available.

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,1 +1,5 @@
-PKG_LIBS = -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32 -lz
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = -lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32 -lz
+else
+  PKG_LIBS = $(shell pkg-config --libs openssl)
+endif


### PR DESCRIPTION
This will get the libraries to link on Windows from pkg-config, when available.